### PR TITLE
Set contrast ratio to MAX_INT for symbols with size less than 1.

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -112,6 +112,10 @@ public class ContrastRatioConsumer implements Consumer<INode> {
 		int y = (int) (Math.round(scaledBBox.getTopY()));
 		int width = getIntegerBBoxValueForProcessing(scaledBBox.getWidth(), 1);
 		int height = getIntegerBBoxValueForProcessing(scaledBBox.getHeight(), 1);
+		if (width <= 1 || height <= 1) {
+			textChunk.setContrastRatio(Integer.MAX_VALUE);
+			return;
+		}
 		try {
 			BufferedImage targetBim = renderedPage.getSubimage(x, renderedPage.getHeight() - y, width,  height);
 			double contrastRatio = getContrastRatio(targetBim, textColorForProcessing);


### PR DESCRIPTION
If width or height of the symbols is <= 1, set contrast ratio to Integer.MAX_INT