### PR TITLE
Fix case when multiplier in adjustSymbolEndsToBoundingBox() could be NaN

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
@@ -201,7 +201,12 @@ public class TextChunk extends TextInfoChunk {
             }
             return;
         }
-        double multiplier = (textEnd - textStart) / (symbolEnds.get(symbolEnds.size() - 1) - symbolEnds.get(0));
+        double multiplier;
+        if (textStart == textEnd) {
+            multiplier = 0;
+        } else {
+            multiplier = (textEnd - textStart) / (symbolEnds.get(symbolEnds.size() - 1) - symbolEnds.get(0));
+        }
         this.symbolEnds = symbolEnds.stream().map(e -> textStart + e * multiplier).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
@@ -202,7 +202,7 @@ public class TextChunk extends TextInfoChunk {
             return;
         }
         double multiplier;
-        if (textStart == textEnd) {
+        if (symbolEnds.get(symbolEnds.size() - 1).equals(symbolEnds.get(0))) {
             multiplier = 0;
         } else {
             multiplier = (textEnd - textStart) / (symbolEnds.get(symbolEnds.size() - 1) - symbolEnds.get(0));

--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/TextChunk.java
@@ -3,6 +3,7 @@ package org.verapdf.wcag.algorithms.entities.content;
 import org.verapdf.wcag.algorithms.entities.enums.TextFormat;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.NodeUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
 
 import java.util.*;
@@ -202,7 +203,7 @@ public class TextChunk extends TextInfoChunk {
             return;
         }
         double multiplier;
-        if (symbolEnds.get(symbolEnds.size() - 1).equals(symbolEnds.get(0))) {
+        if (NodeUtils.areCloseNumbers(symbolEnds.get(symbolEnds.size() - 1), symbolEnds.get(0))) {
             multiplier = 0;
         } else {
             multiplier = (textEnd - textStart) / (symbolEnds.get(symbolEnds.size() - 1) - symbolEnds.get(0));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of degenerate symbol-range cases in text boundary calculations to prevent incorrect position results when symbol endpoints are effectively equal, reducing rare text-processing errors and rendering inaccuracies. This change increases stability and accuracy of text positioning in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->