### PR TITLE
Add threshold to second color percentage in contrast ratio

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -312,7 +312,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
                 return 1.0;
             }
 			textChunk.setBackgroundColor(checkForBackgroundColor(imageColorMap, textColor));
-			List<DataPoint> dpFullArray = new ArrayList<>(new TreeSet<>(imageColorMap.values()));
+			List<DataPoint> dpFullArray = new ArrayList<>(imageColorMap.values());
 			for (DataPoint dp : dpFullArray) {
 				double luminosity = dp.getValue();
 				double currentDifference = Math.abs(luminosity - textLuminosity);
@@ -341,28 +341,21 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 	}
 
     private double getSecondColorPercent(Map<Color, DataPoint> colorMap) {
-        if (colorMap == null || colorMap.isEmpty()) {
-            return 0.0;
-        }
-        int topCount = -1;
-        int secondCount = -1;
-        long totalPixels = 0L;
+        if (colorMap != null && colorMap.size() > 1) {
+            Map.Entry<Color, DataPoint> secondEntry = colorMap.entrySet().stream()
+                    .skip(1)
+                    .findFirst()
+                    .orElse(null);
 
-        for (Map.Entry<Color, DataPoint> e : colorMap.entrySet()) {
-            DataPoint dp = e.getValue();
-            int occ = dp.totalOccurrence;
-            totalPixels += occ;
-            if (occ > topCount) {
-                secondCount = topCount;
-                topCount = occ;
-            } else if (occ > secondCount) {
-                secondCount = occ;
+            if (secondEntry != null) {
+                long totalPixels = colorMap.values().stream()
+                        .mapToInt(DataPoint::getTotalOccurrence)
+                        .sum();
+                DataPoint result = secondEntry.getValue();
+                return (double) result.totalOccurrence / totalPixels;
             }
         }
-        if (totalPixels <= 0 || secondCount <= 0) {
-            return 0.0;
-        }
-        return (double) secondCount / totalPixels;
+        return 0.0;
     }
 
 	private double[] checkForBackgroundColor(Map<Color, DataPoint> imageColorMap, Color textColor) {
@@ -415,11 +408,18 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			}
 		}
 
-		return colorMap;
+        TreeMap<Color, DataPoint> sortedMap = new TreeMap<>((c1, c2) -> {
+            DataPoint dp1 = colorMap.get(c1);
+            DataPoint dp2 = colorMap.get(c2);
+            return Integer.compare(dp2.getTotalOccurrence(), dp1.getTotalOccurrence());
+        });
+        sortedMap.putAll(colorMap);
+
+		return sortedMap;
 	}
 
 	private List<DataPoint> getLuminosityPresenceList(BufferedImage bim) {
-		return new ArrayList<>(new TreeSet<>(getImageColorMap(bim).values()));
+		return new ArrayList<>(getImageColorMap(bim).values());
 	}
 
 	private Color getBackgroundColor(Map<Color, DataPoint> colorMap, Color textColor) {
@@ -430,21 +430,13 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			}
 			return null;
 		}
-		List<Integer> sortedOccurrences = colorMap.values()
-		                                         .stream().map(DataPoint::getTotalOccurrence)
-		                                         .sorted().collect(Collectors.toList());
-		int firstFrequency = sortedOccurrences.get(sortedOccurrences.size() - 1);
-		int secondFrequency = sortedOccurrences.get(sortedOccurrences.size() - 2);
-		Color firstColor = null;
-		Color secondColor = null;
-		for (Map.Entry<Color, DataPoint> entry : colorMap.entrySet()) {
-			if (firstColor == null && entry.getValue().getTotalOccurrence() == firstFrequency) {
-				firstColor = entry.getKey();
-			}
-			if (secondColor == null && entry.getValue().getTotalOccurrence() == secondFrequency) {
-				secondColor = entry.getKey();
-			}
-		}
+        Color firstColor = colorMap.keySet().stream()
+                .findFirst()
+                .orElse(null);
+        Color secondColor = colorMap.keySet().stream()
+                .skip(1)
+                .findFirst()
+                .orElse(null);
 		if (firstColor!= null && !NodeUtils.hasSimilarBackgroundColor(textColor, firstColor)) {
 			return firstColor;
 		} else if (secondColor!= null && !NodeUtils.hasSimilarBackgroundColor(textColor, secondColor)) {
@@ -477,23 +469,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 	}
 
 	private double[] get2MostPresentElements(List<DataPoint> source) {
-		double absoluteMaxPresent = -1;
-		double secondMaxPresent = -1;
-		int max = 0;
-		int secondMax = 0;
-
-		for (DataPoint dataPoint: source) {
-			if (dataPoint.totalOccurrence >= max) {
-				secondMaxPresent = absoluteMaxPresent;
-				secondMax = max;
-				absoluteMaxPresent = dataPoint.value;
-				max = dataPoint.totalOccurrence;
-			} else if (dataPoint.totalOccurrence >= secondMax) {
-				secondMax = dataPoint.totalOccurrence;
-				secondMaxPresent = dataPoint.value;
-			}
-		}
-		return new double[]{absoluteMaxPresent, secondMaxPresent};
+		return source.size() == 1 ? new double[] {source.get(0).value, -1} : new double[] {source.get(0).value, source.get(1).value};
 	}
 
 	@Override

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -43,6 +43,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 	private static final int RENDER_DPI = 144;
 	public static final int PDF_DPI = 72;
 	private static final double LUMINOSITY_DIFFERENCE = 0.001;
+    private static final double SECOND_COLOR_MIN_PERCENTAGE_THRESHOLD = 0.1;
 	private long processedTextChunks;
 	private final Long textChunksNumber;
 	private PDDocument document;
@@ -307,7 +308,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			approximatedTextLuminosity = textLuminosity;
 			double diff = 1.0;
 			Map<Color, DataPoint> imageColorMap = getImageColorMap(image);
-            if (StaticContainers.isDataLoader() && (imageColorMap.size() == 1 || getSecondColorPercent(imageColorMap) < 0.1)) {
+            if (StaticContainers.isDataLoader() && (imageColorMap.size() == 1 || getSecondColorPercent(imageColorMap) < SECOND_COLOR_MIN_PERCENTAGE_THRESHOLD)) {
                 return 1.0;
             }
 			textChunk.setBackgroundColor(checkForBackgroundColor(imageColorMap, textColor));

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -340,7 +340,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 		}
 	}
 
-    private double getSecondColorPercent(Map<Color, DataPoint> colorMap) {
+    private double getSecondColorPercent(SortedMap<Color, DataPoint> colorMap) {
         if (colorMap != null && colorMap.size() > 1) {
             DataPoint secondEntry = colorMap.values().stream()
                     .skip(1)
@@ -410,7 +410,11 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
         TreeMap<Color, DataPoint> sortedMap = new TreeMap<>((c1, c2) -> {
             DataPoint dp1 = colorMap.get(c1);
             DataPoint dp2 = colorMap.get(c2);
-            return Integer.compare(dp2.getTotalOccurrence(), dp1.getTotalOccurrence());
+            int occurrenceCompare = Integer.compare(dp2.getTotalOccurrence(), dp1.getTotalOccurrence());
+            if (occurrenceCompare != 0) {
+                return occurrenceCompare;
+            }
+            return Integer.compare(c1.getRGB(), c2.getRGB());
         });
         sortedMap.putAll(colorMap);
 

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -307,7 +307,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			approximatedTextLuminosity = textLuminosity;
 			double diff = 1.0;
 			Map<Color, DataPoint> imageColorMap = getImageColorMap(image);
-            if (StaticContainers.isDataLoader() && imageColorMap.size() == 1) {
+            if (StaticContainers.isDataLoader() && (imageColorMap.size() == 1 || getSecondColorPercent(imageColorMap) < 0.1)) {
                 return 1.0;
             }
 			textChunk.setBackgroundColor(checkForBackgroundColor(imageColorMap, textColor));
@@ -338,6 +338,31 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			return getContrastRatio(contrastColors[0], contrastColors[1]);
 		}
 	}
+
+    private double getSecondColorPercent(Map<Color, DataPoint> colorMap) {
+        if (colorMap == null || colorMap.isEmpty()) {
+            return 0.0;
+        }
+        int topCount = -1;
+        int secondCount = -1;
+        long totalPixels = 0L;
+
+        for (Map.Entry<Color, DataPoint> e : colorMap.entrySet()) {
+            DataPoint dp = e.getValue();
+            int occ = dp.totalOccurrence;
+            totalPixels += occ;
+            if (occ > topCount) {
+                secondCount = topCount;
+                topCount = occ;
+            } else if (occ > secondCount) {
+                secondCount = occ;
+            }
+        }
+        if (totalPixels <= 0 || secondCount <= 0) {
+            return 0.0;
+        }
+        return (double) secondCount / totalPixels;
+    }
 
 	private double[] checkForBackgroundColor(Map<Color, DataPoint> imageColorMap, Color textColor) {
 		Color backgroundColor = getBackgroundColor(imageColorMap, textColor);

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/ContrastRatioConsumer.java
@@ -307,7 +307,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 			textLuminosity = relativeLuminosity(textColor);
 			approximatedTextLuminosity = textLuminosity;
 			double diff = 1.0;
-			Map<Color, DataPoint> imageColorMap = getImageColorMap(image);
+			SortedMap<Color, DataPoint> imageColorMap = getImageColorMap(image);
             if (StaticContainers.isDataLoader() && (imageColorMap.size() == 1 || getSecondColorPercent(imageColorMap) < SECOND_COLOR_MIN_PERCENTAGE_THRESHOLD)) {
                 return 1.0;
             }
@@ -342,7 +342,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 
     private double getSecondColorPercent(Map<Color, DataPoint> colorMap) {
         if (colorMap != null && colorMap.size() > 1) {
-            Map.Entry<Color, DataPoint> secondEntry = colorMap.entrySet().stream()
+            DataPoint secondEntry = colorMap.values().stream()
                     .skip(1)
                     .findFirst()
                     .orElse(null);
@@ -351,14 +351,13 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
                 long totalPixels = colorMap.values().stream()
                         .mapToInt(DataPoint::getTotalOccurrence)
                         .sum();
-                DataPoint result = secondEntry.getValue();
-                return (double) result.totalOccurrence / totalPixels;
+                return (double) secondEntry.totalOccurrence / totalPixels;
             }
         }
         return 0.0;
     }
 
-	private double[] checkForBackgroundColor(Map<Color, DataPoint> imageColorMap, Color textColor) {
+	private double[] checkForBackgroundColor(SortedMap<Color, DataPoint> imageColorMap, Color textColor) {
 		Color backgroundColor = getBackgroundColor(imageColorMap, textColor);
 		if (backgroundColor != null) {
 			float[] components = backgroundColor.getColorComponents(null);
@@ -385,7 +384,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 		       Math.pow(((doubleColorComponent + 0.055) / 1.055), 2.4);
 	}
 
-	private Map<Color, DataPoint> getImageColorMap(BufferedImage bim) {
+	private SortedMap<Color, DataPoint> getImageColorMap(BufferedImage bim) {
 		int width = bim.getWidth();
 		int height = bim.getHeight();
 		Map<Color, DataPoint> colorMap = new HashMap<>();
@@ -422,7 +421,7 @@ public class ContrastRatioConsumer extends WCAGConsumer implements Consumer<INod
 		return new ArrayList<>(getImageColorMap(bim).values());
 	}
 
-	private Color getBackgroundColor(Map<Color, DataPoint> colorMap, Color textColor) {
+	private Color getBackgroundColor(SortedMap<Color, DataPoint> colorMap, Color textColor) {
 		if (colorMap.size() == 1) {
 			Map.Entry<Color, DataPoint> entry = colorMap.entrySet().iterator().next();
 			if (!textColor.equals(entry.getKey())) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster contrast analysis for images dominated by a single color by short-circuiting detailed processing when the second color is negligibly present.

* **Bug Fixes**
  * More reliable contrast ratio, background and text color detection for near-single-color images; reduces incorrect or redundant processing and improves accuracy.

* **Refactor**
  * Simplified internal color-selection and ordering logic to make results more consistent and maintainable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->