### PR TITLE
Fix NullPointerException in isContainsHeading

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ListUtils.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ListUtils.java
@@ -227,7 +227,7 @@ public class ListUtils {
 	private static boolean isContainsHeading(INode node) {
 		INode currentNode = node;
 		while (currentNode.getPageNumber() != null) {
-			if (HeadingUtils.isDetectedHeadingNode(currentNode) &&
+			if (HeadingUtils.isDetectedHeadingNode(currentNode) && currentNode.getCorrectSemanticScore() != null &&
 					currentNode.getCorrectSemanticScore() >= NodeUtils.MIN_GOOD_HEADING_PROBABILITY) {
 				return true;
 			}


### PR DESCRIPTION
Add check if INode.getCorrectSemanticScore() is not null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added null-safety validation to prevent potential runtime errors during list semantic analysis operations. This improves system stability when processing certain edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->