### PR TITLE
Set MAX_LINES in findTableBorders to 5000

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
@@ -121,4 +121,11 @@ public class LinesCollection {
 		}
 		return squares;
 	}
+
+    public Integer getTotalNumberOfLines(Integer pageNumber) {
+        if (this.horizontalLines.get(pageNumber) == null) {
+            parseLines();
+        }
+        return this.squares.get(pageNumber).size() + this.verticalLines.get(pageNumber).size() + this.horizontalLines.get(pageNumber).size();
+    }
 }

--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
@@ -126,6 +126,6 @@ public class LinesCollection {
         if (this.horizontalLines.get(pageNumber) == null) {
             parseLines();
         }
-        return this.squares.get(pageNumber).size() + this.verticalLines.get(pageNumber).size() + this.horizontalLines.get(pageNumber).size();
+        return getSquares(pageNumber).size() +  getVerticalLines(pageNumber).size() + getHorizontalLines(pageNumber).size();
     }
 }

--- a/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/content/LinesCollection.java
@@ -123,9 +123,6 @@ public class LinesCollection {
 	}
 
     public Integer getTotalNumberOfLines(Integer pageNumber) {
-        if (this.horizontalLines.get(pageNumber) == null) {
-            parseLines();
-        }
         return getSquares(pageNumber).size() +  getVerticalLines(pageNumber).size() + getHorizontalLines(pageNumber).size();
     }
 }

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
@@ -28,10 +28,15 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainer
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.WCAGProgressStatus;
 
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class LinesPreprocessingConsumer extends WCAGConsumer {
 
+    private static final Logger LOGGER = Logger.getLogger(LinesPreprocessingConsumer.class.getCanonicalName());
+
     private static final double MAX_LINE_WIDTH = 5.0;
+    private static final int MAX_LINES = 5000;
 
     private List<List<TableBorderBuilder>> tableBorders;
 
@@ -67,6 +72,11 @@ public class LinesPreprocessingConsumer extends WCAGConsumer {
         Set<LineChunk> set = new HashSet<>(StaticContainers.getLinesCollection().getHorizontalLines(pageNumber));
         set.addAll(StaticContainers.getLinesCollection().getVerticalLines(pageNumber));
         set.addAll(StaticContainers.getLinesCollection().getSquares(pageNumber));
+        if (set.size() > MAX_LINES) {
+            LOGGER.log(Level.WARNING, "There are over {0} lines on the page {1}. Stopped finding table borders",
+                    new Object[]{MAX_LINES, pageNumber + 1});
+            return tableBorders;
+        }
         for (LineChunk line : set) {
             if (line.getWidth() > MAX_LINE_WIDTH) {
                 continue;

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
@@ -69,14 +69,14 @@ public class LinesPreprocessingConsumer extends WCAGConsumer {
 
     private List<TableBorderBuilder> findTableBorders(Integer pageNumber) {
         List<TableBorderBuilder> tableBorders = new ArrayList<>();
-        Set<LineChunk> set = new HashSet<>(StaticContainers.getLinesCollection().getHorizontalLines(pageNumber));
-        set.addAll(StaticContainers.getLinesCollection().getVerticalLines(pageNumber));
-        set.addAll(StaticContainers.getLinesCollection().getSquares(pageNumber));
-        if (set.size() > MAX_NUMBER_OF_LINES_FOR_PAGE) {
+        if (StaticContainers.getLinesCollection().getTotalNumberOfLines(pageNumber) > MAX_NUMBER_OF_LINES_FOR_PAGE) {
             LOGGER.log(Level.WARNING, "There are over {0} lines on the page {1}. Table border finding will be skipped",
                     new Object[]{MAX_NUMBER_OF_LINES_FOR_PAGE, pageNumber + 1});
             return tableBorders;
         }
+        Set<LineChunk> set = new HashSet<>(StaticContainers.getLinesCollection().getHorizontalLines(pageNumber));
+        set.addAll(StaticContainers.getLinesCollection().getVerticalLines(pageNumber));
+        set.addAll(StaticContainers.getLinesCollection().getSquares(pageNumber));
         for (LineChunk line : set) {
             if (line.getWidth() > MAX_LINE_WIDTH) {
                 continue;

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/consumers/LinesPreprocessingConsumer.java
@@ -36,7 +36,7 @@ public class LinesPreprocessingConsumer extends WCAGConsumer {
     private static final Logger LOGGER = Logger.getLogger(LinesPreprocessingConsumer.class.getCanonicalName());
 
     private static final double MAX_LINE_WIDTH = 5.0;
-    private static final int MAX_LINES = 5000;
+    private static final int MAX_NUMBER_OF_LINES_FOR_PAGE = 5000;
 
     private List<List<TableBorderBuilder>> tableBorders;
 
@@ -72,9 +72,9 @@ public class LinesPreprocessingConsumer extends WCAGConsumer {
         Set<LineChunk> set = new HashSet<>(StaticContainers.getLinesCollection().getHorizontalLines(pageNumber));
         set.addAll(StaticContainers.getLinesCollection().getVerticalLines(pageNumber));
         set.addAll(StaticContainers.getLinesCollection().getSquares(pageNumber));
-        if (set.size() > MAX_LINES) {
-            LOGGER.log(Level.WARNING, "There are over {0} lines on the page {1}. Stopped finding table borders",
-                    new Object[]{MAX_LINES, pageNumber + 1});
+        if (set.size() > MAX_NUMBER_OF_LINES_FOR_PAGE) {
+            LOGGER.log(Level.WARNING, "There are over {0} lines on the page {1}. Table border finding will be skipped",
+                    new Object[]{MAX_NUMBER_OF_LINES_FOR_PAGE, pageNumber + 1});
             return tableBorders;
         }
         for (LineChunk line : set) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table border detection performance on complex pages by introducing a per-page cap on how many lines are processed.
  * When a page exceeds the cap, the system now skips border discovery and associated merging/filtering to avoid excessive processing time.

* **Diagnostics**
  * Added warning logs when border processing is skipped, including the impacted page number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->