### PR TITLE
Make image resolution (RENDER_DPI) runtime-settable

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/containers/StaticContainers.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/containers/StaticContainers.java
@@ -82,11 +82,13 @@ public class StaticContainers {
 	private static final ThreadLocal<Boolean> isIgnoreCharactersWithoutUnicode = new ThreadLocal<>();
 
     private static final ThreadLocal<Double> textLineSpaceRatio = new ThreadLocal<>();
+    private static final ThreadLocal<Integer> imageResolution = new ThreadLocal<>();
 
 	static {
 		StaticContainers.wcagValidationInfo.set(new WCAGValidationInfo());
         StaticContainers.setIsDataLoader(false);
         StaticContainers.textLineSpaceRatio.set(TextChunkUtils.TEXT_LINE_SPACE_RATIO);
+        StaticContainers.imageResolution.set(ImagesUtils.RENDER_DPI);
 	}
 
 	public static void updateContainers(IDocument document) {
@@ -120,6 +122,7 @@ public class StaticContainers {
 		StaticContainers.isImagesUtilsFailedToCreate.set(false);
 		StaticContainers.isDataLoader.set(false);
         StaticContainers.textLineSpaceRatio.set(TextChunkUtils.TEXT_LINE_SPACE_RATIO);
+        StaticContainers.imageResolution.set(ImagesUtils.RENDER_DPI);
 		if (StaticContainers.isHuman() == null) {
 			StaticContainers.setIsHuman(true);
 		}
@@ -307,5 +310,13 @@ public class StaticContainers {
 
     public static void setTextLineSpaceRatio(Double textLineSpaceRatio) {
         StaticContainers.textLineSpaceRatio.set(textLineSpaceRatio);
+    }
+
+    public static Integer getImageResolution() {
+        return imageResolution.get();
+    }
+
+    public static void setImageResolution(Integer imageResolution) {
+        StaticContainers.imageResolution.set(imageResolution);
     }
 }

--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ImagesUtils.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ImagesUtils.java
@@ -37,7 +37,7 @@ public class ImagesUtils implements Closeable {
     private PDDocument document;
     private final Map<Integer, Float> renderDpiForPages = new HashMap<>();
     private final Map<Integer, BufferedImage> renderedPages = new HashMap<>();
-    private static final int RENDER_DPI = 288;
+    public static final int RENDER_DPI = 288;
     public static final int PDF_DPI = 72;
 
     private boolean isLoad = false;
@@ -131,7 +131,7 @@ public class ImagesUtils implements Closeable {
         renderingHints.put(RenderingHints.KEY_ANTIALIASING, enableAntialias ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF);
         PDFRenderer pdfRenderer = new PDFRenderer(document);
         pdfRenderer.setRenderingHints(renderingHints);
-        float usedDPI = dpi != null ? dpi.floatValue() : RENDER_DPI;
+        float usedDPI = dpi != null ? dpi.floatValue() : StaticContainers.getImageResolution();
         renderDpiForPages.put(pageNumber, usedDPI / PDF_DPI);
         return pdfRenderer.renderImageWithDPI(pageNumber, usedDPI, ImageType.RGB);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image resolution settings for document rendering.
  * Image resolution can now be adjusted independently for each processing thread.

* **Bug Fixes**
  * Rendering now consistently uses the currently configured image resolution when calculating image scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->