### PR TITLE
Set RENDER_DPI to 144

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ImagesUtils.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/semanticalgorithms/utils/ImagesUtils.java
@@ -37,7 +37,7 @@ public class ImagesUtils implements Closeable {
     private PDDocument document;
     private final Map<Integer, Float> renderDpiForPages = new HashMap<>();
     private final Map<Integer, BufferedImage> renderedPages = new HashMap<>();
-    private static final int RENDER_DPI = 288;
+    private static final int RENDER_DPI = 144;
     public static final int PDF_DPI = 72;
 
     private boolean isLoad = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the default rendering resolution for images when no DPI is specified, improving rendering efficiency while maintaining standard visual output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->