### PR TITLE
Fix inverted topY comparison in BoundingBox.equals

### DIFF
--- a/src/main/java/org/verapdf/wcag/algorithms/entities/geometry/BoundingBox.java
+++ b/src/main/java/org/verapdf/wcag/algorithms/entities/geometry/BoundingBox.java
@@ -192,7 +192,7 @@ public class BoundingBox {
         if (Math.abs(that.rightX - rightX) > EPSILON) {
             return false;
         }
-        return Math.abs(that.topY - topY) > EPSILON;
+        return Math.abs(that.topY - topY) < EPSILON;
     }
 
     public static boolean areSameBoundingBoxes(BoundingBox boundingBox1, BoundingBox boundingBox2) {

--- a/src/test/java/org/verapdf/wcag/algorithms/entities/geometry/BoundingBoxEqualsTests.java
+++ b/src/test/java/org/verapdf/wcag/algorithms/entities/geometry/BoundingBoxEqualsTests.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of veraPDF wcag algorithms, a module of the veraPDF project.
+ * Copyright (c) 2015-2026, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF wcag algorithms is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF wcag algorithms as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF wcag algorithms as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.wcag.algorithms.entities.geometry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class BoundingBoxEqualsTests {
+
+    @Test
+    public void testEqualBoxesAreEqual() {
+        BoundingBox first = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox second = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        Assertions.assertEquals(first, second);
+    }
+
+    @Test
+    public void testBoxesDifferingOnlyInTopYAreNotEqual() {
+        BoundingBox first = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox second = new BoundingBox(0, 0.0, 0.0, 100.0, 70.0);
+        Assertions.assertNotEquals(first, second);
+    }
+
+    /**
+     * equals() and hashCode() must agree: equal boxes have equal hash codes,
+     * which is what every HashSet/HashMap of BoundingBox-keyed entities relies on.
+     */
+    @Test
+    public void testEqualBoxesShareHashCode() {
+        BoundingBox first = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox second = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        Assertions.assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void testEqualsAgreesWithAreSameBoundingBoxes() {
+        BoundingBox first = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox same = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox other = new BoundingBox(0, 0.0, 0.0, 100.0, 70.0);
+        Assertions.assertEquals(BoundingBox.areSameBoundingBoxes(first, same), first.equals(same));
+        Assertions.assertEquals(BoundingBox.areSameBoundingBoxes(first, other), first.equals(other));
+    }
+
+    @Test
+    public void testHashSetDeduplicatesEqualBoxes() {
+        Set<BoundingBox> boxes = new HashSet<>();
+        boxes.add(new BoundingBox(0, 0.0, 0.0, 100.0, 50.0));
+        boxes.add(new BoundingBox(0, 0.0, 0.0, 100.0, 50.0));
+        Assertions.assertEquals(1, boxes.size());
+    }
+
+    @Test
+    public void testBoxesOnDifferentPagesAreNotEqual() {
+        BoundingBox first = new BoundingBox(0, 0.0, 0.0, 100.0, 50.0);
+        BoundingBox second = new BoundingBox(1, 0.0, 0.0, 100.0, 50.0);
+        Assertions.assertNotEquals(first, second);
+    }
+}


### PR DESCRIPTION
`BoundingBox.equals` ends with an inverted comparison:

```java
if (Math.abs(that.leftX   - leftX)   > EPSILON) return false;
if (Math.abs(that.bottomY - bottomY) > EPSILON) return false;
if (Math.abs(that.rightX  - rightX)  > EPSILON) return false;
return Math.abs(that.topY - topY) > EPSILON;   // <-- should be <
```

The first three coordinates reject when they differ; the last one *accepts* when it differs. So two identical boxes compare unequal, and two boxes differing only in `topY` compare equal.

The two sibling helpers in the same class — `areSameBoundingBoxes` and `areSameBoundingBoxesExcludingPages` — run the same four checks and end with `< EPSILON`. This change makes `equals` consistent with them.

It also restores the `equals`/`hashCode` contract: `hashCode()` mixes in `topY`, so under the current `equals` two "equal" boxes can hash differently.

## Impact

`BoundingBox.equals` backs `equals` on `InfoChunk` and everything derived from it (`Vertex`, `LineChunk`, `ImageChunk`, `LineArtChunk`, semantic nodes), so every `HashSet`/`HashMap` keyed on those silently keeps duplicates today.

The clearest case is `TableBorderBuilder.vertexes`. For a 3x3 ruling grid (3 horizontal + 3 vertical lines) the set holds **12 vertexes instead of 8**, because each of the 4 shared corners is inserted twice. `getVertexesNumber()` feeds the `<= 2` discard check in `LinesPreprocessingConsumer`, and the vertex set feeds `TableBorder`'s cell matrix, so the inflated count is observable downstream.

The duplicates also keep those sets larger than intended on line-heavy pages, which may be relevant to the per-page cap added in #392 — that cap does not trigger below 5000 lines per page.

## Tests

Added `BoundingBoxEqualsTests`: equal boxes compare equal, boxes differing only in `topY` do not, `equals` agrees with `areSameBoundingBoxes`, `HashSet` deduplicates equal boxes, equal boxes share a hash code, and boxes on different pages are not equal. Four of the six fail without this change.

Existing suite is unaffected: 333 tests pass before, 339 after.
